### PR TITLE
Exclude book when publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ homepage.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
+exclude = ["book"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
```
$ cargo package
```

**Before**:

```
Packaged 126 files, 915.0KiB (605.6KiB compressed)
```

**After**:

```
Packaged 74 files, 118.1KiB (27.9KiB compressed)
```
