### PR TITLE
Fix semver range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ keywords = ["macro", "framework", "proc", "rust"]
 categories = ["development-tools::procedural-macro-helpers", "rust-patterns", "no-std"]
 
 [workspace.dependencies]
-zyn-core = { path = "./crates/core", version = "0.3.10" }
-zyn-derive = { path = "./crates/derive", version = "0.3.10" }
+zyn-core = { path = "./crates/core", version = "=0.3.10" }
+zyn-derive = { path = "./crates/derive", version = "=0.3.10" }
 
 # ----------- Package ----------- #
 


### PR DESCRIPTION
`version = "0.3.10"` is `version = ">=0.3.10,<0.4.0"`

Assigning a version range in the internal package may lead to bugs, and I have encountered this issue before

Reference: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio
