### PR TITLE
feat(meta): add Neg variant to Arg for negated flags

### DIFF
--- a/crates/zyn-core/src/extract/mod.rs
+++ b/crates/zyn-core/src/extract/mod.rs
@@ -328,7 +328,7 @@ mod tests {
 
         #[test]
         fn from_neg() {
-            let arg: Arg = syn::parse_str("-debug").unwrap();
+            let arg: Arg = syn::parse_str("!debug").unwrap();
             assert!(!bool::from_arg(&arg).unwrap());
         }
 

--- a/crates/zyn-core/src/extract/mod.rs
+++ b/crates/zyn-core/src/extract/mod.rs
@@ -170,6 +170,7 @@ impl FromArg for bool {
     fn from_arg(arg: &Arg) -> crate::Result<Self> {
         match arg {
             Arg::Flag(_) => Ok(true),
+            Arg::Neg(_) => Ok(false),
             _ => Err(mark::error("expected flag for bool")
                 .span(arg.span())
                 .build()),
@@ -236,7 +237,7 @@ impl FromArg for char {
 impl FromArg for syn::Ident {
     fn from_arg(arg: &Arg) -> crate::Result<Self> {
         match arg {
-            Arg::Flag(i) => Ok(i.clone()),
+            Arg::Flag(i) | Arg::Neg(i) => Ok(i.clone()),
             _ => Err(mark::error("expected identifier").span(arg.span()).build()),
         }
     }
@@ -245,7 +246,7 @@ impl FromArg for syn::Ident {
 impl FromArg for syn::Path {
     fn from_arg(arg: &Arg) -> crate::Result<Self> {
         match arg {
-            Arg::Flag(i) => Ok(syn::Path::from(i.clone())),
+            Arg::Flag(i) | Arg::Neg(i) => Ok(syn::Path::from(i.clone())),
             _ => Err(mark::error("expected identifier for path")
                 .span(arg.span())
                 .build()),
@@ -323,6 +324,12 @@ mod tests {
         fn from_flag() {
             let arg: Arg = syn::parse_str("skip").unwrap();
             assert!(bool::from_arg(&arg).unwrap());
+        }
+
+        #[test]
+        fn from_neg() {
+            let arg: Arg = syn::parse_str("-debug").unwrap();
+            assert!(!bool::from_arg(&arg).unwrap());
         }
 
         #[test]

--- a/crates/zyn-core/src/meta/arg.rs
+++ b/crates/zyn-core/src/meta/arg.rs
@@ -13,7 +13,7 @@ use super::Args;
 
 /// A single parsed attribute argument.
 ///
-/// Represents one of five forms: a bare flag (`skip`), a negated flag (`-debug`),
+/// Represents one of five forms: a bare flag (`skip`), a negated flag (`!debug`),
 /// a key-value expression (`rename = "foo"`), a nested list (`serde(flatten)`),
 /// or a standalone literal (`"hello"`).
 #[derive(Clone)]
@@ -42,7 +42,7 @@ impl Arg {
         matches!(self, Self::Flag(_))
     }
 
-    /// Returns `true` if this is a negated flag (e.g. `-debug`).
+    /// Returns `true` if this is a negated flag (e.g. `!debug`).
     pub fn is_neg(&self) -> bool {
         matches!(self, Self::Neg(_))
     }
@@ -194,8 +194,8 @@ impl Parse for Arg {
             return Ok(Self::Lit(input.parse()?));
         }
 
-        if input.peek(Token![-]) {
-            input.parse::<Token![-]>()?;
+        if input.peek(Token![!]) {
+            input.parse::<Token![!]>()?;
             let name: Ident = input.parse()?;
             return Ok(Self::Neg(name));
         }
@@ -222,7 +222,7 @@ impl ToTokens for Arg {
         match self {
             Self::Flag(name) => name.to_tokens(tokens),
             Self::Neg(name) => {
-                tokens.append(proc_macro2::Punct::new('-', proc_macro2::Spacing::Joint));
+                tokens.append(proc_macro2::Punct::new('!', proc_macro2::Spacing::Joint));
                 name.to_tokens(tokens);
             }
             Self::Expr(name, expr) => {
@@ -259,7 +259,7 @@ mod tests {
 
         #[test]
         fn neg() {
-            let arg: Arg = syn::parse_str("-debug").unwrap();
+            let arg: Arg = syn::parse_str("!debug").unwrap();
             assert!(arg.is_neg());
             assert_eq!(arg.name().unwrap(), "debug");
         }
@@ -305,9 +305,9 @@ mod tests {
 
         #[test]
         fn neg() {
-            let arg: Arg = syn::parse_str("-debug").unwrap();
+            let arg: Arg = syn::parse_str("!debug").unwrap();
             let output = arg.to_token_stream().to_string();
-            assert_eq!(output, "-debug");
+            assert_eq!(output, "!debug");
         }
 
         #[test]
@@ -364,7 +364,7 @@ mod tests {
 
         #[test]
         fn as_neg_returns_ident() {
-            let arg: Arg = syn::parse_str("-debug").unwrap();
+            let arg: Arg = syn::parse_str("!debug").unwrap();
             assert_eq!(arg.as_neg().to_string(), "debug");
         }
 

--- a/crates/zyn-core/src/meta/arg.rs
+++ b/crates/zyn-core/src/meta/arg.rs
@@ -222,7 +222,7 @@ impl ToTokens for Arg {
         match self {
             Self::Flag(name) => name.to_tokens(tokens),
             Self::Neg(name) => {
-                tokens.append(proc_macro2::Punct::new('-', proc_macro2::Spacing::Alone));
+                tokens.append(proc_macro2::Punct::new('-', proc_macro2::Spacing::Joint));
                 name.to_tokens(tokens);
             }
             Self::Expr(name, expr) => {
@@ -307,7 +307,7 @@ mod tests {
         fn neg() {
             let arg: Arg = syn::parse_str("-debug").unwrap();
             let output = arg.to_token_stream().to_string();
-            assert_eq!(output, "- debug");
+            assert_eq!(output, "-debug");
         }
 
         #[test]

--- a/crates/zyn-core/src/meta/arg.rs
+++ b/crates/zyn-core/src/meta/arg.rs
@@ -13,11 +13,13 @@ use super::Args;
 
 /// A single parsed attribute argument.
 ///
-/// Represents one of four forms: a bare flag (`skip`), a key-value expression
-/// (`rename = "foo"`), a nested list (`serde(flatten)`), or a standalone literal (`"hello"`).
+/// Represents one of five forms: a bare flag (`skip`), a negated flag (`-debug`),
+/// a key-value expression (`rename = "foo"`), a nested list (`serde(flatten)`),
+/// or a standalone literal (`"hello"`).
 #[derive(Clone)]
 pub enum Arg {
     Flag(Ident),
+    Neg(Ident),
     Expr(Ident, Expr),
     List(Ident, Args),
     Lit(Lit),
@@ -28,6 +30,7 @@ impl Arg {
     pub fn name(&self) -> Option<&Ident> {
         match self {
             Self::Flag(name) => Some(name),
+            Self::Neg(name) => Some(name),
             Self::Expr(name, _) => Some(name),
             Self::List(name, _) => Some(name),
             Self::Lit(_) => None,
@@ -37,6 +40,11 @@ impl Arg {
     /// Returns `true` if this is a bare flag (e.g. `skip`).
     pub fn is_flag(&self) -> bool {
         matches!(self, Self::Flag(_))
+    }
+
+    /// Returns `true` if this is a negated flag (e.g. `-debug`).
+    pub fn is_neg(&self) -> bool {
+        matches!(self, Self::Neg(_))
     }
 
     /// Returns `true` if this is a key-value expression (e.g. `rename = "foo"`).
@@ -83,6 +91,14 @@ impl Arg {
         match self {
             Self::Flag(i) => i,
             _ => panic!("called `Arg::as_flag()` on a non-Flag variant"),
+        }
+    }
+
+    /// Returns the negated flag identifier. Panics if not a `Neg` variant.
+    pub fn as_neg(&self) -> &Ident {
+        match self {
+            Self::Neg(i) => i,
+            _ => panic!("called `Arg::as_neg()` on a non-Neg variant"),
         }
     }
 
@@ -178,6 +194,12 @@ impl Parse for Arg {
             return Ok(Self::Lit(input.parse()?));
         }
 
+        if input.peek(Token![-]) {
+            input.parse::<Token![-]>()?;
+            let name: Ident = input.parse()?;
+            return Ok(Self::Neg(name));
+        }
+
         let name: Ident = input.parse()?;
 
         if input.peek(Token![=]) {
@@ -199,6 +221,10 @@ impl ToTokens for Arg {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         match self {
             Self::Flag(name) => name.to_tokens(tokens),
+            Self::Neg(name) => {
+                tokens.append(proc_macro2::Punct::new('-', proc_macro2::Spacing::Alone));
+                name.to_tokens(tokens);
+            }
             Self::Expr(name, expr) => {
                 name.to_tokens(tokens);
                 tokens.append(proc_macro2::Punct::new('=', proc_macro2::Spacing::Alone));
@@ -229,6 +255,13 @@ mod tests {
             let arg: Arg = syn::parse_str("skip").unwrap();
             assert!(arg.is_flag());
             assert_eq!(arg.name().unwrap(), "skip");
+        }
+
+        #[test]
+        fn neg() {
+            let arg: Arg = syn::parse_str("-debug").unwrap();
+            assert!(arg.is_neg());
+            assert_eq!(arg.name().unwrap(), "debug");
         }
 
         #[test]
@@ -268,6 +301,13 @@ mod tests {
             let arg: Arg = syn::parse_str("skip").unwrap();
             let output = arg.to_token_stream().to_string();
             assert_eq!(output, "skip");
+        }
+
+        #[test]
+        fn neg() {
+            let arg: Arg = syn::parse_str("-debug").unwrap();
+            let output = arg.to_token_stream().to_string();
+            assert_eq!(output, "- debug");
         }
 
         #[test]
@@ -320,6 +360,19 @@ mod tests {
         fn as_flag_returns_ident() {
             let arg: Arg = syn::parse_str("skip").unwrap();
             assert_eq!(arg.as_flag().to_string(), "skip");
+        }
+
+        #[test]
+        fn as_neg_returns_ident() {
+            let arg: Arg = syn::parse_str("-debug").unwrap();
+            assert_eq!(arg.as_neg().to_string(), "debug");
+        }
+
+        #[test]
+        #[should_panic(expected = "non-Neg")]
+        fn as_neg_panics_on_flag() {
+            let arg: Arg = syn::parse_str("skip").unwrap();
+            arg.as_neg();
         }
 
         #[test]

--- a/crates/zyn-core/src/meta/args.rs
+++ b/crates/zyn-core/src/meta/args.rs
@@ -31,14 +31,14 @@ impl Args {
 
     /// Returns `true` if a positive flag (not negated) with the given name exists.
     ///
-    /// Unlike [`has`](Self::has), this returns `false` for negated flags (`-name`).
+    /// Unlike [`has`](Self::has), this returns `false` for negated flags (`!name`).
     pub fn has_flag(&self, name: &str) -> bool {
         self.0
             .iter()
             .any(|arg| matches!(arg, Arg::Flag(n) if n == name))
     }
 
-    /// Returns `true` if a negated flag (`-name`) with the given name exists.
+    /// Returns `true` if a negated flag (`!name`) with the given name exists.
     pub fn has_neg(&self, name: &str) -> bool {
         self.0
             .iter()
@@ -234,14 +234,14 @@ mod tests {
 
         #[test]
         fn has_flag_negated() {
-            let args: Args = syn::parse_str("-debug").unwrap();
+            let args: Args = syn::parse_str("!debug").unwrap();
             assert!(!args.has_flag("debug"));
             assert!(args.has("debug"));
         }
 
         #[test]
         fn has_flag_mixed() {
-            let args: Args = syn::parse_str("debug, -clone").unwrap();
+            let args: Args = syn::parse_str("debug, !clone").unwrap();
             assert!(args.has_flag("debug"));
             assert!(!args.has_flag("clone"));
         }
@@ -254,7 +254,7 @@ mod tests {
 
         #[test]
         fn has_neg_negated() {
-            let args: Args = syn::parse_str("-debug").unwrap();
+            let args: Args = syn::parse_str("!debug").unwrap();
             assert!(args.has_neg("debug"));
         }
 

--- a/crates/zyn-core/src/meta/args.rs
+++ b/crates/zyn-core/src/meta/args.rs
@@ -29,6 +29,22 @@ impl Args {
             .any(|arg| arg.name().is_some_and(|n| n == name))
     }
 
+    /// Returns `true` if a positive flag (not negated) with the given name exists.
+    ///
+    /// Unlike [`has`](Self::has), this returns `false` for negated flags (`-name`).
+    pub fn has_flag(&self, name: &str) -> bool {
+        self.0
+            .iter()
+            .any(|arg| matches!(arg, Arg::Flag(n) if n == name))
+    }
+
+    /// Returns `true` if a negated flag (`-name`) with the given name exists.
+    pub fn has_neg(&self, name: &str) -> bool {
+        self.0
+            .iter()
+            .any(|arg| matches!(arg, Arg::Neg(n) if n == name))
+    }
+
     /// Returns the first argument with the given name.
     pub fn get(&self, name: &str) -> Option<&Arg> {
         self.0
@@ -207,6 +223,39 @@ mod tests {
         fn has_missing() {
             let args: Args = syn::parse_str("skip").unwrap();
             assert!(!args.has("rename"));
+        }
+
+        #[test]
+        fn has_flag_positive() {
+            let args: Args = syn::parse_str("debug").unwrap();
+            assert!(args.has_flag("debug"));
+            assert!(args.has("debug"));
+        }
+
+        #[test]
+        fn has_flag_negated() {
+            let args: Args = syn::parse_str("-debug").unwrap();
+            assert!(!args.has_flag("debug"));
+            assert!(args.has("debug"));
+        }
+
+        #[test]
+        fn has_flag_mixed() {
+            let args: Args = syn::parse_str("debug, -clone").unwrap();
+            assert!(args.has_flag("debug"));
+            assert!(!args.has_flag("clone"));
+        }
+
+        #[test]
+        fn has_neg_positive() {
+            let args: Args = syn::parse_str("debug").unwrap();
+            assert!(!args.has_neg("debug"));
+        }
+
+        #[test]
+        fn has_neg_negated() {
+            let args: Args = syn::parse_str("-debug").unwrap();
+            assert!(args.has_neg("debug"));
         }
 
         #[test]

--- a/crates/zyn-derive/src/attribute/emit.rs
+++ b/crates/zyn-derive/src/attribute/emit.rs
@@ -88,8 +88,13 @@ pub fn from_args(
                                     struct_inits.push(quote! {
                                         #ident: match args.get(#key) {
                                             ::std::option::Option::Some(arg) => {
-                                                <bool as ::zyn::FromArg>::from_arg(arg)
-                                                    .unwrap_or_else(|_| #expr)
+                                                match <bool as ::zyn::FromArg>::from_arg(arg) {
+                                                    ::std::result::Result::Ok(v) => v,
+                                                    ::std::result::Result::Err(e) => {
+                                                        __diags = __diags.add(e);
+                                                        #expr
+                                                    }
+                                                }
                                             }
                                             ::std::option::Option::None => #expr,
                                         }

--- a/crates/zyn-derive/src/attribute/emit.rs
+++ b/crates/zyn-derive/src/attribute/emit.rs
@@ -57,7 +57,47 @@ pub fn from_args(
                 known_keys.push(key.clone());
 
                 if f.is_bool() {
-                    struct_inits.push(quote! { #ident: args.has(#key) });
+                    match &f.default {
+                        FieldDefault::None | FieldDefault::Unit => {
+                            // No default or Default::default() → off unless flagged
+                            struct_inits.push(quote! { #ident: args.has_flag(#key) });
+                        }
+                        FieldDefault::Expr(expr) => {
+                            let bool_lit =
+                                syn::parse2::<syn::Expr>(expr.clone())
+                                    .ok()
+                                    .and_then(|e| match e {
+                                        syn::Expr::Lit(syn::ExprLit {
+                                            lit: syn::Lit::Bool(b),
+                                            ..
+                                        }) => Some(b.value),
+                                        _ => None,
+                                    });
+
+                            match bool_lit {
+                                Some(true) => {
+                                    // default = true → on unless -name
+                                    struct_inits.push(quote! { #ident: !args.has_neg(#key) });
+                                }
+                                Some(false) => {
+                                    // default = false → same as no default
+                                    struct_inits.push(quote! { #ident: args.has_flag(#key) });
+                                }
+                                None => {
+                                    // Non-literal expression (e.g. a function call)
+                                    struct_inits.push(quote! {
+                                        #ident: match args.get(#key) {
+                                            ::std::option::Option::Some(arg) => {
+                                                <bool as ::zyn::FromArg>::from_arg(arg)
+                                                    .unwrap_or_else(|_| #expr)
+                                            }
+                                            ::std::option::Option::None => #expr,
+                                        }
+                                    });
+                                }
+                            }
+                        }
+                    }
                     continue;
                 }
 

--- a/crates/zyn-derive/src/attribute/emit.rs
+++ b/crates/zyn-derive/src/attribute/emit.rs
@@ -76,7 +76,7 @@ pub fn from_args(
 
                             match bool_lit {
                                 Some(true) => {
-                                    // default = true → on unless -name
+                                    // default = true → on unless !name
                                     struct_inits.push(quote! { #ident: !args.has_neg(#key) });
                                 }
                                 Some(false) => {

--- a/tests/attribute/structs.rs
+++ b/tests/attribute/structs.rs
@@ -266,3 +266,84 @@ fn unknown_key_with_valid_fields_still_errors() {
     assert!(combined.contains("unknown argument `bogus`"));
     assert_eq!(err.len(), 1);
 }
+
+// -- bool + default + Neg tests --
+
+#[derive(zyn::Attribute)]
+#[zyn("feat")]
+struct Features {
+    // default on: enabled unless explicitly negated
+    #[zyn(default = true)]
+    debug: bool,
+    #[zyn(default)]
+    clone: bool,
+    // default off: enabled only when explicitly flagged
+    display: bool,
+}
+
+#[test]
+fn bool_default_true_when_absent() {
+    let args: Args = zyn::parse!("").unwrap();
+    let v = Features::from_args(&args).unwrap();
+
+    assert!(v.debug, "default = true should make bool true when absent");
+    assert!(
+        !v.clone,
+        "#[zyn(default)] on bool is Default::default() = false"
+    );
+    assert!(!v.display, "plain bool should be false when absent");
+}
+
+#[test]
+fn bool_neg_disables_default_true() {
+    let args: Args = zyn::parse!("-debug, -clone").unwrap();
+    let v = Features::from_args(&args).unwrap();
+
+    assert!(!v.debug, "-debug should disable default-true field");
+    assert!(!v.clone, "-clone on default bool stays false");
+}
+
+#[test]
+fn bool_flag_enables_plain() {
+    let args: Args = zyn::parse!("display").unwrap();
+    let v = Features::from_args(&args).unwrap();
+
+    assert!(v.debug, "default = true stays true when not negated");
+    assert!(!v.clone, "#[zyn(default)] bool stays false without flag");
+    assert!(v.display, "explicit flag enables plain bool");
+}
+
+#[test]
+fn bool_mixed_flags() {
+    let args: Args = zyn::parse!("display, -debug").unwrap();
+    let v = Features::from_args(&args).unwrap();
+
+    assert!(!v.debug, "-debug should be false");
+    assert!(!v.clone, "clone default stays false");
+    assert!(v.display, "display explicitly enabled");
+}
+
+#[derive(zyn::Attribute)]
+#[zyn("bool_default_false")]
+struct BoolDefaultFalse {
+    #[zyn(default = false)]
+    enabled: bool,
+}
+
+#[test]
+fn bool_default_false_same_as_no_default() {
+    // absent → false
+    let args: Args = zyn::parse!("").unwrap();
+    let v = BoolDefaultFalse::from_args(&args).unwrap();
+    assert!(!v.enabled);
+
+    // flag → true
+    let args: Args = zyn::parse!("enabled").unwrap();
+    let v = BoolDefaultFalse::from_args(&args).unwrap();
+    assert!(v.enabled);
+
+    // neg → false
+    let args: Args = zyn::parse!("-enabled").unwrap();
+    let v = BoolDefaultFalse::from_args(&args).unwrap();
+    assert!(!v.enabled);
+}

--- a/tests/attribute/structs.rs
+++ b/tests/attribute/structs.rs
@@ -296,11 +296,11 @@ fn bool_default_true_when_absent() {
 
 #[test]
 fn bool_neg_disables_default_true() {
-    let args: Args = zyn::parse!("-debug, -clone").unwrap();
+    let args: Args = zyn::parse!("!debug, !clone").unwrap();
     let v = Features::from_args(&args).unwrap();
 
-    assert!(!v.debug, "-debug should disable default-true field");
-    assert!(!v.clone, "-clone on default bool stays false");
+    assert!(!v.debug, "!debug should disable default-true field");
+    assert!(!v.clone, "!clone on default bool stays false");
 }
 
 #[test]
@@ -315,10 +315,10 @@ fn bool_flag_enables_plain() {
 
 #[test]
 fn bool_mixed_flags() {
-    let args: Args = zyn::parse!("display, -debug").unwrap();
+    let args: Args = zyn::parse!("display, !debug").unwrap();
     let v = Features::from_args(&args).unwrap();
 
-    assert!(!v.debug, "-debug should be false");
+    assert!(!v.debug, "!debug should be false");
     assert!(!v.clone, "clone default stays false");
     assert!(v.display, "display explicitly enabled");
 }
@@ -343,7 +343,7 @@ fn bool_default_false_same_as_no_default() {
     assert!(v.enabled);
 
     // neg → false
-    let args: Args = zyn::parse!("-enabled").unwrap();
+    let args: Args = zyn::parse!("!enabled").unwrap();
     let v = BoolDefaultFalse::from_args(&args).unwrap();
     assert!(!v.enabled);
 }


### PR DESCRIPTION
Add support for negated flags (e.g. !debug, !clone) to disable bool fields in #[derive(Attribute)] structs.

Changes:
- Add Arg::Neg(Ident) variant with parsing, ToTokens, is_neg(), as_neg()
- Add Args::has_flag() and Args::has_neg() for variant-aware queries
- FromArg for bool: Neg returns false (Flag returns true)
- FromArg for Ident/Path: accept both Flag and Neg
- emit.rs: bool fields respect #[zyn(default = true/false)]
  - default = true  → !args.has_neg(key) (on unless negated)
  - default = false → args.has_flag(key) (same as no default)
  - non-literal expr → generic match + FromArg fallback

Usage:
  #[derive(Attribute)]
  #[zyn("opt")]
  struct Opt {
      #[zyn(default = true)]
      debug: bool,   // on by default, use !debug to disable
      display: bool, // off by default, use display to enable
  }